### PR TITLE
Added scam link

### DIFF
--- a/urls.json
+++ b/urls.json
@@ -8577,5 +8577,6 @@
   "z93729n9.beget.tech",
   "zeusclicks.com",
   "zipansion.com",
-  "zipsetgo.com"
+  "zipsetgo.com",
+  "dis-kord.com"
 ]


### PR DESCRIPTION
Full scam link is <https://dis-kord.com/steam/nitro1> base domain doesn't actually point to anything