### PR TITLE
Remove adf.ly and adfoc.us

### DIFF
--- a/urls.json
+++ b/urls.json
@@ -72,8 +72,6 @@
   "adcell.de",
   "added-hypesquad.com",
   "adexchangecloud.com",
-  "adf.ly",
-  "adfoc.us",
   "adforce.com",
   "ads-apply-hype.com",
   "ads-discord.com",


### PR DESCRIPTION
These domains are only redirect domains and aren't actually used for phishing.